### PR TITLE
Reusando JAXBContext, DocumentBuilderFactory e SoapHttpClient

### DIFF
--- a/src/main/java/br/ufsc/bridge/soap/SoapClient.java
+++ b/src/main/java/br/ufsc/bridge/soap/SoapClient.java
@@ -1,0 +1,28 @@
+package br.ufsc.bridge.soap;
+
+import org.apache.http.HttpHeaders;
+
+import br.ufsc.bridge.soap.http.SoapHttpClient;
+import br.ufsc.bridge.soap.http.SoapHttpRequest;
+import br.ufsc.bridge.soap.http.SoapHttpResponse;
+import br.ufsc.bridge.soap.http.exception.SoapHttpConnectionException;
+import br.ufsc.bridge.soap.http.exception.SoapHttpResponseException;
+
+public class SoapClient {
+
+	static {
+		client = new SoapHttpClient();
+	}
+
+	private static SoapHttpClient client;
+
+	private SoapClient() {
+		// utility class
+	}
+
+	public static SoapHttpResponse request(SoapHttpRequest request) throws SoapHttpResponseException, SoapHttpConnectionException {
+		request.addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip,deflate");
+		return client.request(request);
+	}
+
+}

--- a/src/main/java/br/ufsc/bridge/soap/http/SoapHttpClient.java
+++ b/src/main/java/br/ufsc/bridge/soap/http/SoapHttpClient.java
@@ -1,14 +1,11 @@
 package br.ufsc.bridge.soap.http;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
-import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
@@ -26,7 +23,6 @@ import br.ufsc.bridge.soap.http.util.ByteArrayOutputStreamNoCopy;
 @Slf4j
 public class SoapHttpClient {
 	private CloseableHttpClient httpClient;
-	private Map<String, String> customHeaders;
 
 	public SoapHttpClient() {
 		this(RequestConfig.custom()
@@ -53,24 +49,13 @@ public class SoapHttpClient {
 
 	public SoapHttpClient(CloseableHttpClient httpClient) {
 		this.httpClient = httpClient;
-
-		this.customHeaders = new HashMap<>();
-		this.putHeader(HttpHeaders.ACCEPT_ENCODING, "gzip,deflate");
-	}
-
-	public void putHeader(String key, String value) {
-		if (value != null) {
-			this.customHeaders.put(key, value);
-		} else {
-			this.customHeaders.remove(key);
-		}
 	}
 
 	public SoapHttpResponse request(SoapHttpRequest soapHttpRequest) throws SoapHttpResponseException, SoapHttpConnectionException {
 		HttpRequestBase httpRequest = null;
 		ByteArrayOutputStreamNoCopy baos = null;
 		try {
-			HttpResponse response = this.httpClient.execute(httpRequest = soapHttpRequest.httpRequest(this.customHeaders));
+			HttpResponse response = this.httpClient.execute(httpRequest = soapHttpRequest.httpRequest());
 
 			int responseCode = response.getStatusLine().getStatusCode();
 			if (responseCode == HttpStatus.SC_INTERNAL_SERVER_ERROR) {

--- a/src/main/java/br/ufsc/bridge/soap/http/SoapHttpRequest.java
+++ b/src/main/java/br/ufsc/bridge/soap/http/SoapHttpRequest.java
@@ -76,12 +76,9 @@ public class SoapHttpRequest {
 		return this;
 	}
 
-	public HttpRequestBase httpRequest(Map<String, String> customHeaders) {
+	public HttpRequestBase httpRequest() {
 		HttpPost httpPost = new HttpPost(this.url);
 		httpPost.setEntity(this.httpEntity());
-		for (Map.Entry<String, String> header : customHeaders.entrySet()) {
-			httpPost.setHeader(header.getKey(), header.getValue());
-		}
 		for (Entry<String, String> header : this.headers.entrySet()) {
 			httpPost.setHeader(header.getKey(), header.getValue());
 		}

--- a/src/main/java/br/ufsc/bridge/soap/http/SoapMessageBuilder.java
+++ b/src/main/java/br/ufsc/bridge/soap/http/SoapMessageBuilder.java
@@ -29,7 +29,7 @@ import br.ufsc.bridge.soap.jaxb.JAXBContextWrapper;
 @Slf4j
 @AllArgsConstructor
 public class SoapMessageBuilder {
-	private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+
 	protected SoapCredential c;
 
 	public byte[] createMessage(Object jaxbObject) throws SoapCreateMessageException {
@@ -96,7 +96,7 @@ public class SoapMessageBuilder {
 	protected Document jaxbObjectToDocument(Object data) throws JAXBException, ParserConfigurationException {
 		JAXBContext jc = JAXBContextWrapper.newInstance(data.getClass());
 
-		Document document = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder().newDocument();
+		Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
 
 		Marshaller marshaller = jc.createMarshaller();
 		marshaller.marshal(data, document);

--- a/src/main/java/br/ufsc/bridge/soap/http/SoapMessageBuilder.java
+++ b/src/main/java/br/ufsc/bridge/soap/http/SoapMessageBuilder.java
@@ -24,15 +24,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.w3c.dom.Document;
 
 import br.ufsc.bridge.soap.http.exception.SoapCreateMessageException;
-import br.ufsc.bridge.soap.http.exception.SoapHttpConnectionException;
-import br.ufsc.bridge.soap.http.exception.SoapHttpResponseException;
+import br.ufsc.bridge.soap.jaxb.JAXBContextWrapper;
 
 @Slf4j
 @AllArgsConstructor
 public class SoapMessageBuilder {
+	private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
 	protected SoapCredential c;
 
-	public byte[] createMessage(Object jaxbObject) throws SoapCreateMessageException, SoapHttpResponseException, SoapHttpConnectionException {
+	public byte[] createMessage(Object jaxbObject) throws SoapCreateMessageException {
 		try {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			this.soapMessage(jaxbObject).writeTo(outputStream);
@@ -94,9 +94,9 @@ public class SoapMessageBuilder {
 	}
 
 	protected Document jaxbObjectToDocument(Object data) throws JAXBException, ParserConfigurationException {
-		JAXBContext jc = JAXBContext.newInstance(data.getClass());
+		JAXBContext jc = JAXBContextWrapper.newInstance(data.getClass());
 
-		Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+		Document document = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder().newDocument();
 
 		Marshaller marshaller = jc.createMarshaller();
 		marshaller.marshal(data, document);

--- a/src/main/java/br/ufsc/bridge/soap/jaxb/JAXBContextWrapper.java
+++ b/src/main/java/br/ufsc/bridge/soap/jaxb/JAXBContextWrapper.java
@@ -1,0 +1,28 @@
+package br.ufsc.bridge.soap.jaxb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+public class JAXBContextWrapper {
+
+	private static Map<Class<?>, JAXBContext> contextByClass = new HashMap<>();
+
+	private JAXBContextWrapper() {
+		// utility class
+	}
+
+	public static JAXBContext newInstance(Class<?> clazz) throws JAXBException {
+		JAXBContext context = contextByClass.get(clazz);
+
+		if (context == null) {
+			context = JAXBContext.newInstance(clazz);
+			contextByClass.put(clazz, context);
+		}
+
+		return context;
+	}
+
+}

--- a/src/test/java/br/ufsc/bridge/soap/http/SoapHttpRequestTest.java
+++ b/src/test/java/br/ufsc/bridge/soap/http/SoapHttpRequestTest.java
@@ -38,8 +38,8 @@ public class SoapHttpRequestTest {
 	@Test
 	public void applicationSoap() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, ACTION, BODY_BYTE);
-		request.addHeader("SOAPAction", ACTION);
 		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
+		request.addHeader("SOAPAction", ACTION);
 
 		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/app-soap.txt"), httpPostToString(httpPost));
@@ -48,8 +48,8 @@ public class SoapHttpRequestTest {
 	@Test
 	public void applicationSoapNoAction() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, null, BODY_BYTE);
-		request.addHeader("SOAPAction", ACTION);
 		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
+		request.addHeader("SOAPAction", ACTION);
 
 		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/app-soap-noaction.txt"), httpPostToString(httpPost));
@@ -58,8 +58,8 @@ public class SoapHttpRequestTest {
 	@Test
 	public void simpleMultipart() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, ACTION, BODY, BODY_BYTE);
-		request.addHeader("SOAPAction", ACTION);
 		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
+		request.addHeader("SOAPAction", ACTION);
 
 		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/simple-multipart.txt"), httpPostToString(httpPost));
@@ -68,8 +68,8 @@ public class SoapHttpRequestTest {
 	@Test
 	public void simpleMultipartNoAction() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, null, BODY, BODY_BYTE);
-		request.addHeader("SOAPAction", ACTION);
 		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
+		request.addHeader("SOAPAction", ACTION);
 
 		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/simple-multipart-noaction.txt"), httpPostToString(httpPost));
@@ -81,8 +81,8 @@ public class SoapHttpRequestTest {
 		parts.put(PART2, PART2_BYTE);
 		parts.put(PART1, PART1_BYTE);
 		SoapHttpRequest request = new SoapHttpRequest(URL, ACTION, BODY, BODY_BYTE, parts);
-		request.addHeader("SOAPAction", ACTION);
 		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
+		request.addHeader("SOAPAction", ACTION);
 
 		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/multipart.txt"), httpPostToString(httpPost));

--- a/src/test/java/br/ufsc/bridge/soap/http/SoapHttpRequestTest.java
+++ b/src/test/java/br/ufsc/bridge/soap/http/SoapHttpRequestTest.java
@@ -28,48 +28,50 @@ public class SoapHttpRequestTest {
 	public static byte[] PART1_BYTE;
 	public static byte[] PART2_BYTE;
 
-	private HashMap<String, String> headers;
-
 	@Before
 	public void init() throws Exception {
 		BODY_BYTE = BODY.getBytes("UTF-8");
 		PART1_BYTE = PART1.getBytes("UTF-8");
 		PART2_BYTE = PART2.getBytes("UTF-8");
-
-		this.headers = new LinkedHashMap<>();
-		this.headers.put(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
-		this.headers.put("SOAPAction", ACTION);
 	}
 
 	@Test
 	public void applicationSoap() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, ACTION, BODY_BYTE);
+		request.addHeader("SOAPAction", ACTION);
+		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
 
-		HttpRequestBase httpPost = request.httpRequest(this.headers);
+		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/app-soap.txt"), httpPostToString(httpPost));
 	}
 
 	@Test
 	public void applicationSoapNoAction() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, null, BODY_BYTE);
+		request.addHeader("SOAPAction", ACTION);
+		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
 
-		HttpRequestBase httpPost = request.httpRequest(this.headers);
+		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/app-soap-noaction.txt"), httpPostToString(httpPost));
 	}
 
 	@Test
 	public void simpleMultipart() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, ACTION, BODY, BODY_BYTE);
+		request.addHeader("SOAPAction", ACTION);
+		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
 
-		HttpRequestBase httpPost = request.httpRequest(this.headers);
+		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/simple-multipart.txt"), httpPostToString(httpPost));
 	}
 
 	@Test
 	public void simpleMultipartNoAction() throws IOException {
 		SoapHttpRequest request = new SoapHttpRequest(URL, null, BODY, BODY_BYTE);
+		request.addHeader("SOAPAction", ACTION);
+		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
 
-		HttpRequestBase httpPost = request.httpRequest(this.headers);
+		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/simple-multipart-noaction.txt"), httpPostToString(httpPost));
 	}
 
@@ -79,8 +81,10 @@ public class SoapHttpRequestTest {
 		parts.put(PART2, PART2_BYTE);
 		parts.put(PART1, PART1_BYTE);
 		SoapHttpRequest request = new SoapHttpRequest(URL, ACTION, BODY, BODY_BYTE, parts);
+		request.addHeader("SOAPAction", ACTION);
+		request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip,deflate");
 
-		HttpRequestBase httpPost = request.httpRequest(this.headers);
+		HttpRequestBase httpPost = request.httpRequest();
 		Assert.assertEquals(SoapTestFileUtils.toString("/http-post/multipart.txt"), httpPostToString(httpPost));
 	}
 

--- a/src/test/java/br/ufsc/bridge/soap/jaxb/JAXBContextWrapperTest.java
+++ b/src/test/java/br/ufsc/bridge/soap/jaxb/JAXBContextWrapperTest.java
@@ -1,0 +1,19 @@
+package br.ufsc.bridge.soap.jaxb;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JAXBContextWrapperTest {
+
+	@Test
+	public void shouldReturnTheSameInstance() throws JAXBException {
+		JAXBContext instance1 = JAXBContextWrapper.newInstance(this.getClass());
+		JAXBContext instance2 = JAXBContextWrapper.newInstance(this.getClass());
+
+		Assert.assertSame(instance1, instance2);
+	}
+
+}

--- a/src/test/resources/http-post/app-soap-noaction.txt
+++ b/src/test/resources/http-post/app-soap-noaction.txt
@@ -1,6 +1,6 @@
 POST http://localhost HTTP/1.1
-Content-Encoding: gzip,deflate
 SOAPAction: Teste
+Content-Encoding: gzip,deflate
 Content-Type: application/soap+xml; charset=UTF-8
 
 body

--- a/src/test/resources/http-post/app-soap.txt
+++ b/src/test/resources/http-post/app-soap.txt
@@ -1,6 +1,6 @@
 POST http://localhost HTTP/1.1
-Content-Encoding: gzip,deflate
 SOAPAction: Teste
+Content-Encoding: gzip,deflate
 Content-Type: application/soap+xml; charset=UTF-8; action=Teste
 
 body

--- a/src/test/resources/http-post/multipart.txt
+++ b/src/test/resources/http-post/multipart.txt
@@ -1,6 +1,6 @@
 POST http://localhost HTTP/1.1
-Content-Encoding: gzip,deflate
 SOAPAction: Teste
+Content-Encoding: gzip,deflate
 Content-Type: multipart/related; boundary=MIMEboundary; type="application/xop+xml"; start-info="application/soap+xml"; start="<body>"; action=Teste
 
 --MIMEboundary\r

--- a/src/test/resources/http-post/simple-multipart-noaction.txt
+++ b/src/test/resources/http-post/simple-multipart-noaction.txt
@@ -1,6 +1,6 @@
 POST http://localhost HTTP/1.1
-Content-Encoding: gzip,deflate
 SOAPAction: Teste
+Content-Encoding: gzip,deflate
 Content-Type: multipart/related; boundary=MIMEboundary; type="application/xop+xml"; start-info="application/soap+xml"; start="<body>"
 
 --MIMEboundary\r

--- a/src/test/resources/http-post/simple-multipart.txt
+++ b/src/test/resources/http-post/simple-multipart.txt
@@ -1,6 +1,6 @@
 POST http://localhost HTTP/1.1
-Content-Encoding: gzip,deflate
 SOAPAction: Teste
+Content-Encoding: gzip,deflate
 Content-Type: multipart/related; boundary=MIMEboundary; type="application/xop+xml"; start-info="application/soap+xml"; start="<body>"; action=Teste
 
 --MIMEboundary\r


### PR DESCRIPTION
Será que vale uma estratégia pra guardar só um número limitado de `context` no `JAXBContextWrapper`?